### PR TITLE
Update GA4 tag, fixup a focus state, add meta sharing image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      name="description"
-      content="Drag and drop a GeoTIFF from your computer in order to see its information."
-    />
+    <meta name="description" content="Drag and drop a GeoTIFF from your computer in order to see its information." />
 
     <link
       rel="apple-touch-icon"
@@ -46,9 +43,28 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+
+    <!-- Primary Meta Tags -->
+    <meta name="title" content="Azavea Loam: Run GDAL in the browser">
+    <meta name="description" content="Drag and drop a GeoTIFF from your computer in order to see its information.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://geotiffinfo.com">
+    <meta property="og:title" content="Azavea Loam: Run GDAL in the browser">
+    <meta property="og:description" content="Drag and drop a GeoTIFF from your computer in order to see its information.">
+    <meta property="og:image" content="https://geotiffinfo.com/meta-image.jpg">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://geotiffinfo.com">
+    <meta property="twitter:title" content="Azavea Loam: Run GDAL in the browser">
+    <meta property="twitter:description" content="Drag and drop a GeoTIFF from your computer in order to see its information.">
+    <meta property="twitter:image" content="https://geotiffinfo.com/meta-image.jpg">
+
     <title>Azavea Loam: Run GDAL in the browser</title>
 
-    <!-- Fonts - New Hero from Adobe -->
+    <!-- Fonts - Adobe Typekit -->
     <link rel="stylesheet" href="https://use.typekit.net/hkv8jkn.css" />
 
     <!-- FontAwesome Kit -->
@@ -60,7 +76,7 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=G-TK1P24NKL9"
+      src="https://www.googletagmanager.com/gtag/js?id=G-331SYDD6B2"
     ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -69,7 +85,7 @@
       }
       gtag('js', new Date());
 
-      gtag('config', 'G-TK1P24NKL9');
+      gtag('config', 'G-331SYDD6B2');
     </script>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -312,6 +312,7 @@ main {
   flex-direction: column;
   width: 100%;
   align-items: center;
+  justify-content: center;
 }
 
 /* ****************** */
@@ -499,7 +500,6 @@ main {
   position: relative;
   border: 2px dashed #fff;
   background: #000;
-  width: 90%;
   margin: 0 auto;
   padding: 1rem;
   overflow: hidden;
@@ -511,7 +511,16 @@ main {
     background: transparent;
     border-radius: 100%;
     padding: 0;
-    margin-top: 25%;
+  }
+}
+
+.drag-container__focus {
+    overflow: hidden;
+}
+
+@media screen and (max-width: 46.8em) {
+  .drag-container__focus {
+    width: 90%;
   }
 }
 


### PR DESCRIPTION
# Overview
- Updates Data Stream in GA4 to use the correct url for this demo
- Fixed the drag-and-drop focus state, which was misaligned
- Added references to the meta sharing image.

# Testing
- Note: We won't be able to see if the GA4 tag worked until tomorrow. It takes at least a day for this stuff to appear. So we should check!
- Try and share the Netlify link in Twitter's tester: https://cards-dev.twitter.com/validator
- Try and share the Netlify link in Slack.
- Try and share the Nelify link in Facebook's tester: https://developers.facebook.com/tools/debug/